### PR TITLE
Don't throw exception if the header has authorization and a token set…

### DIFF
--- a/starlette_jwt/middleware.py
+++ b/starlette_jwt/middleware.py
@@ -48,6 +48,8 @@ class JWTAuthenticationBackend(AuthenticationBackend):
 
         auth = request.headers["Authorization"]
         token = self.get_token_from_header(authorization=auth, prefix=self.prefix)
+        if token == 'undefined':
+            return
         try:
             payload = jwt.decode(token, key=self.secret_key)
         except jwt.InvalidTokenError as e:


### PR DESCRIPTION
… to undefined

A common pattern with Single Pages Applications is to add an http interceptor that would add the Authorization header to all calls even those that are not meant to be under auth. They just set an 'undefined' token and lets the credentials do the rest.
This change allows such request to pass through the same way as if they don't had the Authorization header.