### PR TITLE
Add algorithm parameter to support RS256

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # HISTORY
 
+## 0.1.5
+
+Adds RS256 support by allowing to pass the jwt algorithm to JWTAuthenticationBackend
+
 ## 0.1.4
 
 Supports now starlette>=0.9.3 and uses the AuthenticationMiddleware.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,17 @@ Store your secret key in this setting while creating the middleware:
 app.add_middleware(AuthenticationMiddleware, backend=JWTAuthenticationBackend(secret_key='MY SECRET KEY'))
 ```
 
+*algorithm*
+
+Configures the jwt algorithm to use (defaults to "HS256"):
+```python
+public_key = b'-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEAC...'
+app.add_middleware(AuthenticationMiddleware, backend=JWTAuthenticationBackend(secret_key=public_key, algorithm='RS256'))
+```
+
 *prefix*
 
-Change the Authorization header prefix string (defualts to "JWT"):
+Change the Authorization header prefix string (defaults to "JWT"):
 ```python
 # Example: changes the prefix to Bearer
 app.add_middleware(AuthenticationMiddleware, backend=JWTAuthenticationBackend(secret_key='secret', prefix='Bearer'))

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ test_requirements = [
 
 setup(
     name='starlette_jwt',
-    version='0.1.4',
+    version='0.1.5',
     description="A JSON Web Token Middleware for Starlette",
     long_description=readme,
     author="Amit Ripshtos",

--- a/starlette_jwt/middleware.py
+++ b/starlette_jwt/middleware.py
@@ -21,8 +21,9 @@ class JWTUser(BaseUser):
 
 class JWTAuthenticationBackend(AuthenticationBackend):
 
-    def __init__(self, secret_key: str, prefix: str = 'JWT', username_field: str = 'username'):
+    def __init__(self, secret_key: str, algorithm: str = 'HS256', prefix: str = 'JWT', username_field: str = 'username'):
         self.secret_key = secret_key
+        self.algorithm = algorithm
         self.prefix = prefix
         self.username_field = username_field
 
@@ -49,7 +50,7 @@ class JWTAuthenticationBackend(AuthenticationBackend):
         auth = request.headers["Authorization"]
         token = self.get_token_from_header(authorization=auth, prefix=self.prefix)
         try:
-            payload = jwt.decode(token, key=self.secret_key)
+            payload = jwt.decode(token, key=self.secret_key, algorithms=self.algorithm)
         except jwt.InvalidTokenError as e:
             raise AuthenticationError(str(e))
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -36,36 +36,36 @@ def test_header_parse():
 
     # Without prefix
     response = client.get("/auth",
-                          headers=dict(Authorization=jwt.encode(dict(username="user"), secret_key).decode()))
+                          headers=dict(Authorization=jwt.encode(dict(username="user"), secret_key, algorithm='HS256').decode()))
     assert response.text == 'Could not separate Authorization scheme and token'
     assert response.status_code == 400
 
     # Wrong prefix
     response = client.get("/auth",
-                          headers=dict(Authorization=f'WRONG {jwt.encode(dict(username="user"), secret_key).decode()}'))
+                          headers=dict(Authorization=f'WRONG {jwt.encode(dict(username="user"), secret_key, algorithm="HS256").decode()}'))
     assert response.text == 'Authorization scheme WRONG is not supported'
     assert response.status_code == 400
 
     # Good headers
-    response = client.get("/auth", headers=dict(Authorization=f'JWT {jwt.encode(dict(username="user"), secret_key).decode()}'))
+    response = client.get("/auth", headers=dict(Authorization=f'JWT {jwt.encode(dict(username="user"), secret_key, algorithm="HS256").decode()}'))
     assert response.json() == {"auth": {"username": "user"}}
     assert response.status_code == 200
 
     # Wrong secret key
     response = client.get("/auth",
-                          headers=dict(Authorization=f'JWT {jwt.encode(dict(username="user"), "BAD SECRET").decode()}'))
+                          headers=dict(Authorization=f'JWT {jwt.encode(dict(username="user"), "BAD SECRET", algorithm="HS256").decode()}'))
     assert response.text == 'Signature verification failed'
     assert response.status_code == 400
 
 
 def test_get_token_from_header():
-    token = jwt.encode(dict(username="user"), 'secret').decode()
+    token = jwt.encode(dict(username="user"), 'secret', algorithm="HS256").decode()
     assert token == JWTAuthenticationBackend.get_token_from_header(authorization=f'JWT {token}', prefix='JWT')
 
 
 def test_user_object():
     payload = dict(username="user")
-    token = jwt.encode(payload, "BAD SECRET").decode()
+    token = jwt.encode(payload, "BAD SECRET", algorithm="HS256").decode()
     user_object = JWTUser(username="user", payload=payload, token=token)
     assert user_object.is_authenticated == True
     assert user_object.display_name == 'user'


### PR DESCRIPTION
This PR adds support for RS256 by allowing one to pass the jwt algorithm to `JWTAuthenticationBackend`

It defaults to HS256 as not to break existing setups.

The underlying pyjwt library will deprecate using `decode` without passing the algorithm explicitly: https://github.com/jpadilla/pyjwt/blob/master/jwt/api_jwt.py#L77