### PR TITLE
Bugfix wrongly opened connection without Header

### DIFF
--- a/starlette_jwt/middleware.py
+++ b/starlette_jwt/middleware.py
@@ -1,7 +1,7 @@
 import jwt
 from starlette.authentication import (
-    AuthenticationBackend, AuthenticationError, BaseUser, AuthCredentials
-)
+    AuthenticationBackend, AuthenticationError, BaseUser, AuthCredentials,
+    UnauthenticatedUser)
 
 
 class JWTUser(BaseUser):
@@ -45,7 +45,9 @@ class JWTAuthenticationBackend(AuthenticationBackend):
 
     async def authenticate(self, request):
         if "Authorization" not in request.headers:
-            return
+            if request.scope["type"] == "websocket":
+                return AuthCredentials(), UnauthenticatedUser()
+            return None
 
         auth = request.headers["Authorization"]
         token = self.get_token_from_header(authorization=auth, prefix=self.prefix)


### PR DESCRIPTION
When a user tries to open a WebSocket connection without the
Authorization Header an AuthenticationError-Exception must be raised
instead of returning None.

Reproducible with:
```python
secret = b'-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALFc9NFZaOaSwUMPNektbtJqEjYZ6IRB\nqhqvJu1hKPYn9HYd75c0gIDYHJ9lb7QwQvg44aO27104rDK0xSstzL0CAwEAAQ==\n-----END PUBLIC KEY-----'

app = Starlette(debug=True)
app.add_middleware(AuthenticationMiddleware, backend=JWTAuthenticationBackend(
    secret_key=secret,
    prefix='JWT',
    algorithm='RS256',
    username_field='username'
))


@app.websocket_route("/")
class Notification(WebSocketEndpoint):
    encoding = "text"

    @requires('authenticated')
    async def on_connect(self, websocket):
        await websocket.accept()
        await websocket.send_text('Connection established')

    @requires('authenticated')
    async def on_receive(self, websocket, data):
        await websocket.send_text(f"Message text was: {data}")

    @requires('authenticated')
    async def on_disconnect(self, websocket, close_code):
        await websocket.close()


if __name__ == "__main__":
    uvicorn.run(app, host='0.0.0.0', port=8000)
```
On console:
```
uvicorn app.main:app --reload --log-level info --host 0.0.0.0 --port 8081
wscat -c ws://localhost:8081/
```