### PR TITLE
Refactor JWT Websocket Authorization

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # HISTORY
 
+##  0.1.6
+
+Bugfix wrongly opened ws-connection without Header
+Added cryptography package as a requirement for tests
+Added tests to RSA256 algorithm with starlette-jwt
+
 ## 0.1.5
 
 Adds RS256 support by allowing to pass the jwt algorithm to JWTAuthenticationBackend

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ test_requirements = [
 
 setup(
     name='starlette_jwt',
-    version='0.1.5',
+    version='0.1.6',
     description="A JSON Web Token Middleware for Starlette",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Purpose
Most web browsers are not supporting headers in their WebSocket implementation for security reasons.
The authorization via `query parameters` is the recommended alternative.

## Approach
Add a `JWTWebSocketAuthenticationBackend` middleware for this use case.